### PR TITLE
Splitting modals on other pages

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -238,9 +238,11 @@ app.get('/friend-requests', async (req, res) => {
             FROM friends f
             JOIN users u1 ON f.user_id = u1.id
             JOIN users u2 ON f.friend_id = u2.id
-            WHERE (f.user_id = ? OR f.friend_id = ?) AND f.status = 'pending'`,
-            [userId, userId]
+            WHERE f.friend_id = ? AND f.status = 'pending'`,
+            [userId]
         );
+
+
 
         res.json(requests);
     } catch (error) {


### PR DESCRIPTION
Добавление корректного вывода заявок в друзья и реализована логика, что при поптыке добавления или отклонения самого себя будет выдаваться ошибка. Так и должно быть, так как мы не можем добавить самого себя в друзья

## Summary by Sourcery

Implements friend request functionality, including sending, receiving, and accepting friend requests. It also prevents users from sending friend requests to themselves or sending duplicate requests.

New Features:
- Introduced an endpoint for sending friend requests, including validation to prevent duplicate requests and self-requests.

Enhancements:
- Modified the /friends endpoint to retrieve friends in both directions, ensuring that the list includes users who have added the current user as a friend.
- Improved the /friend-requests endpoint to fetch only pending friend requests.